### PR TITLE
[plugin.video.bravo] 3.0.6

### DIFF
--- a/plugin.video.bravo/README.txt
+++ b/plugin.video.bravo/README.txt
@@ -10,7 +10,8 @@ https://commons.wikimedia.org/wiki/File:Bravo_TV.svg
 fanart.jpg sourced from public domain:
 https://commons.wikimedia.org/wiki/File:Bravo_TV.svg (converted to .jpg)
 
-Version 3.0.5 on-line episodes added by Chris Prince. website changes
+Version 3.0.6 fixed online-only episodes
+Version 3.0.5 website changes, added online-only episodes
 Version 3.0.4 website change
 Version 3.0.3 website change, ability to add TV shows to library
 Version 3.0.2 website change & cleanup

--- a/plugin.video.bravo/addon.xml
+++ b/plugin.video.bravo/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.bravo"
        name="Bravo"
-       version="3.0.5"
+       version="3.0.6"
        provider-name="t1m">
   <requires>
     <import addon="xbmc.python" version="2.20.0"/>
@@ -13,7 +13,7 @@
   </extension>
   <extension point="xbmc.addon.metadata">
     <summary lang="en">Bravo TV Video Addon</summary>
-    <description lang="en">Bravo TV Video Addon.  On-line episodes added by Chris Prince.</description>
+    <description lang="en">Bravo TV Video Addon.</description>
     <disclaimer lang="en">Feel free to use this script. For information visit the wiki.</disclaimer>
     <platform>all</platform>
     <language>en</language>

--- a/plugin.video.bravo/changelog.txt
+++ b/plugin.video.bravo/changelog.txt
@@ -1,4 +1,5 @@
-Version 3.0.5 on-line episodes added by Chris Prince. website changes
+Version 3.0.6 fixed online-only episodes
+Version 3.0.5 website changes, added online-only episodes
 Version 3.0.4 website change
 Version 3.0.3 website change, ability to add TV shows to library
 Version 3.0.2 website change & cleanup

--- a/plugin.video.bravo/resources/lib/scraper.py
+++ b/plugin.video.bravo/resources/lib/scraper.py
@@ -43,7 +43,7 @@ class myAddon(t1mAddon):
       self.defaultVidStream['height'] = 1080
       epiHTML = self.getRequest(url)
       (tvshow,  fanart) = re.compile('og:title" content="(.+?)".+?"og:image" content="(.+?)"',re.DOTALL).search(epiHTML).groups()
-      epis = re.compile('full-episode-teaser.+?href="(.+?)".+?</article>',re.DOTALL).findall(epiHTML)
+      epis = re.compile('<article.+?(?:full-episode-teaser|field-video-subtype">\s+(?:Digital Original|Digital Series|Exclusive)).+?class="headline.+?href="(.+?)".+?</article>',re.DOTALL).findall(epiHTML)
       for url in epis:
           burl = BRAVOBASE % url
           html = self.getRequest(burl)

--- a/plugin.video.bravo/resources/lib/scraper.py
+++ b/plugin.video.bravo/resources/lib/scraper.py
@@ -43,11 +43,7 @@ class myAddon(t1mAddon):
       self.defaultVidStream['height'] = 1080
       epiHTML = self.getRequest(url)
       (tvshow,  fanart) = re.compile('og:title" content="(.+?)".+?"og:image" content="(.+?)"',re.DOTALL).search(epiHTML).groups()
-<<<<<<< HEAD
       epis = re.compile('full-episode-teaser.+?href="(.+?)".+?</article>',re.DOTALL).findall(epiHTML)
-=======
-      epis =  re.compile('(?:class="watch__title|class="field-video-subtype">\s+(?:Exclusive|Digital Original|Digital Series)).+?href="(.+?)".+?</a>',re.DOTALL).findall(epiHTML)
->>>>>>> origin/master
       for url in epis:
           burl = BRAVOBASE % url
           html = self.getRequest(burl)


### PR DESCRIPTION
This fixes the scraping of Bravo online-only episodes.

This also removes my name from the plugin description. It was very considerate of you to mention me, but I'd rather remain unmentioned. :)

Finally, this bumps the version number to 3.0.6.  I believe the new release of the plugin should be ready to push after you merge this pull request.
